### PR TITLE
Fix/redshift terraform

### DIFF
--- a/terraform/modules/redshift/redshift.tf
+++ b/terraform/modules/redshift/redshift.tf
@@ -22,7 +22,6 @@ resource "aws_redshift_cluster" "redshift_cluster" {
 # Create an IAM role for the Redshift cluster to access other AWS services
 resource "aws_iam_role" "redshift_role" {
   name = "${var.prefix}-redshift-role-${var.random_id}"
-
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [


### PR DESCRIPTION
Redshift now defaults to being unavailable from public networks unless the `publicly_accessible` [terraform argument](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster#publicly_accessible-1) is set to true